### PR TITLE
Remove dependency between build_path and working_path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -108,22 +108,10 @@ runs:
                 npm run build -- --base=$PUBLIC_BASE_PATH #${{ inputs.public_base_path }}
               fi
         shell: bash
-      - name: Set artifact path
-        run: |
-          if [[ "${{ inputs.build_path }}" == /* ]]; then
-            echo "ARTIFACT_PATH=${{ inputs.build_path }}" >> $GITHUB_ENV
-          else
-            if [ "${{ inputs.working_path }}" = "./" ]; then
-              echo "ARTIFACT_PATH=${{ inputs.build_path }}" >> $GITHUB_ENV
-            else
-              echo "ARTIFACT_PATH=${{ inputs.working_path }}/${{ inputs.build_path }}" >> $GITHUB_ENV
-            fi
-          fi
-        shell: bash
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ${{ env.ARTIFACT_PATH }}
+          path: ${{ inputs.build_path }}
           name: ${{ inputs.artifact_name }}
 
       - name: Deploy


### PR DESCRIPTION
Following up after merging #14, I thought it would be good idea to complete separate the concerns of `build_path` and `working_path`, in order to allow projects that follow the following folder structure:

```
.
├── src/ (target for `working_directory`. Classes, services, etc. Actual source code.)
├── dist/ (target for `build_path`, this is where the built files are put to, the output of the build command)
├── docs/
├── LICENSE
└── README.md
```

With this change, now we can support the example folder structure provided above. Previously, it wouldn't have been possible, because it would merge two paths together, it was assuming that the `dist/` (or build output) would always reside under the `working_directory`, which may not be the case all the time.


Compatibility with one of the test repos: [repository](https://github.com/skywarth/document-embeddings) and [deployment](https://github.com/skywarth/document-embeddings/actions/runs/13190957834), and the [workflow file](https://github.com/skywarth/document-embeddings/actions/runs/13190957834/workflow)